### PR TITLE
Add FizzBuzz stage 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,c++
+
+build/

--- a/FizzBuzz/App/FizzBuzz.cpp
+++ b/FizzBuzz/App/FizzBuzz.cpp
@@ -1,40 +1,40 @@
 #include "FizzBuzz.h"
 
 FizzBuzz::FizzBuzz()
-    : FizzDivisor(DefaultFizzValue)
-    , BuzzDivisor(DefaultBuzzValue)
 {
+    FizzMatcherFunction = nullptr;
+    BuzzMatcherFunction = nullptr;
 }
 
-int FizzBuzz::SetFizzValue(const int FizzValue)
+int FizzBuzz::SetFizzMatcher(bool (*fizzMatcher)(const int))
 {
-    FizzDivisor = FizzValue;
+    FizzMatcherFunction = fizzMatcher;
     return 0;
 }
 
-int FizzBuzz::SetBuzzValue(const int BuzzValue)
+int FizzBuzz::SetBuzzMatcher(bool (*buzzMatcher)(const int))
 {
-    BuzzDivisor = BuzzValue;
+    BuzzMatcherFunction = buzzMatcher;
     return 0;
 }
 
-std::vector<std::string> FizzBuzz::Run(const int LowerLimit, const int UpperLimit)
+std::vector<std::string> FizzBuzz::Run(const int lowerLimit, const int upperLimit)
 {
     std::vector<std::string> result = {};
 
-    if(LowerLimit > 0)
+    if(lowerLimit > 0)
     {
-        result = FizzBuzzLoop(LowerLimit, UpperLimit);
+        result = FizzBuzzLoop(lowerLimit, upperLimit);
     }
 
     return result;
 }
 
-std::vector<std::string> FizzBuzz::FizzBuzzLoop(const int LowerLimit, const int UpperLimit)
+std::vector<std::string> FizzBuzz::FizzBuzzLoop(const int lowerLimit, const int upperLimit)
 {
     std::vector<std::string> result = {};
 
-    for(int i = LowerLimit; i <= UpperLimit; ++i)
+    for(int i = lowerLimit; i <= upperLimit; ++i)
     {
         std::string numberString;
         AddFizzIfNeeded(numberString, i);
@@ -49,18 +49,38 @@ std::vector<std::string> FizzBuzz::FizzBuzzLoop(const int LowerLimit, const int 
 
 int FizzBuzz::AddFizzIfNeeded(std::string& numberString, const int value)
 {
-    if(value % FizzDivisor == 0)
+    if(FizzMatcherFunction != nullptr)
     {
-        numberString.append(FizzString);
+        if(FizzMatcherFunction(value))
+        {
+            numberString.append(FizzString);
+        }
+    }
+    else
+    {
+        if(DefaultFizzMatcher(value))
+        {
+            numberString.append(FizzString);
+        }
     }
     return 0;
 }
 
 int FizzBuzz::AddBuzzIfNeeded(std::string& numberString, const int value)
 {
-    if(value % BuzzDivisor == 0)
+    if(BuzzMatcherFunction != nullptr)
     {
-        numberString.append(BuzzString);
+        if(BuzzMatcherFunction(value))
+        {
+            numberString.append(BuzzString);
+        }
+    }
+    else
+    {
+        if(DefaultBuzzMatcher(value))
+        {
+            numberString.append(BuzzString);
+        }
     }
     return 0;
 }
@@ -72,4 +92,14 @@ int FizzBuzz::AddNumberIfNeeded(std::string& numberString, const int value)
         numberString.append(std::to_string(value));
     }
     return 0;
+}
+
+bool FizzBuzz::DefaultFizzMatcher(const int testValue)
+{
+    return testValue % DefaultFizzValue == 0;
+}
+
+bool FizzBuzz::DefaultBuzzMatcher(const int testValue)
+{
+    return testValue % DefaultBuzzValue == 0;
 }

--- a/FizzBuzz/App/FizzBuzz.h
+++ b/FizzBuzz/App/FizzBuzz.h
@@ -13,18 +13,20 @@ class FizzBuzz
 
 public:
     FizzBuzz();
-    int SetFizzValue(const int FizzValue = DefaultFizzValue);
-    int SetBuzzValue(const int BuzzValue = DefaultBuzzValue);
-    std::vector<std::string> Run(const int LowerLimit, const int UpperLimit);
+    int SetFizzMatcher(bool (*fizzMatcher)(const int) = nullptr);
+    int SetBuzzMatcher(bool (*buzzMatcher)(const int) = nullptr);
+    std::vector<std::string> Run(const int lowerLimit, const int upperLimit);
 
 private:
-    std::vector<std::string> FizzBuzzLoop(const int LowerLimit, const int UpperLimit);
+    std::vector<std::string> FizzBuzzLoop(const int lowerLimit, const int upperLimit);
     int AddFizzIfNeeded(std::string& numberString, const int i);
     int AddBuzzIfNeeded(std::string& numberString, const int i);
     int AddNumberIfNeeded(std::string& numberString, const int i);
+    bool DefaultFizzMatcher(const int testValue);
+    bool DefaultBuzzMatcher(const int testValue);
 
     int StartValue;
     int EndValue;
-    int FizzDivisor;
-    int BuzzDivisor;
+    bool (*FizzMatcherFunction)(const int);
+    bool (*BuzzMatcherFunction)(const int);
 };

--- a/FizzBuzz/README.md
+++ b/FizzBuzz/README.md
@@ -5,6 +5,17 @@ purposes. It practices:
 - OOP design for extensibility
 - TDD
 
+Attempted extending to stage 2 requirements and misunderstood what should happen. I thought the
+algorithm should print Fizz or Buzz if either of the conditions were true, but still only print
+once. The actual requirement is that it will print Fizz or Buzz each time one of the requirements
+is met.
+
+The updated implementation is with my incorrect understanding in mind. I've created the ability
+for a user of the FizzBuzz class to provide a custom matcher function for either of the strings.
+I've decided not to extend this further to incorporate the correct interpretation of the
+requirements. If I did, I would probably try to construct a list of matchers the user could add to,
+and check each one, printing Fizz or Buzz for each one.
+
 # Docker
 The project has been dockerized for convience. If you have docker installed, build and run the app
 using the following:

--- a/FizzBuzz/Tests/FizzBuzzTests.cpp
+++ b/FizzBuzz/Tests/FizzBuzzTests.cpp
@@ -1,8 +1,42 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <string>
 #include "FizzBuzz.h"
 
 using namespace testing;
+
+bool fizzOnMultipleOfFour(const int testValue) { return testValue % 4 == 0; }
+bool buzzOnMutlipleOfSix(const int testValue) { return testValue % 6 == 0; }
+bool fizzOnMultipleOfOrContainsThree(const int testValue) {
+    int thisNumber = testValue >= 0 ? testValue : -testValue;
+    int thisDigit;
+    bool found = false;
+    while (thisNumber != 0)
+    {
+        thisDigit = thisNumber % 10;
+        thisNumber = thisNumber / 10;
+        if (thisDigit == 3)
+        {
+            found = true;
+            break;
+        }
+    }
+    return (testValue % 3 == 0) || found; }
+bool buzzOnMutlipleOfOrContainsFive(const int testValue) {
+    int thisNumber = testValue >= 0 ? testValue : -testValue;
+    int thisDigit;
+    bool found = false;
+    while (thisNumber != 0)
+    {
+        thisDigit = thisNumber % 10;
+        thisNumber = thisNumber / 10;
+        if (thisDigit == 5)
+        {
+            found = true;
+            break;
+        }
+    }
+    return (testValue % 5 == 0) || found; }
 
 TEST(FizzBuzzTest, GivenDefaults_WhenRunRange1To5_ThenCorrectStringReturned)
 {
@@ -16,8 +50,6 @@ TEST(FizzBuzzTest, GivenDefaults_WhenRunRange1To10_ThenCorrectStringReturned)
 {
     std::vector<std::string> expected = {"1", "2", "Fizz", "4", "Buzz", "Fizz", "7", "8", "Fizz", "Buzz"};
     FizzBuzz fizzBuzz;
-    fizzBuzz.SetFizzValue();
-    fizzBuzz.SetBuzzValue();
     std::vector<std::string> result = fizzBuzz.Run(1, 10);
     EXPECT_THAT(result, Eq(expected));
 }
@@ -30,13 +62,41 @@ TEST(FizzBuzzTest, GivenDefaults_WhenRunRange1To15_ThenCorrectStringReturned)
     EXPECT_THAT(result, Eq(expected));
 }
 
-TEST(FizzBuzzTest, GivenFizz4Buzz6_WhenRunRange1To12_ThenCorrectStringReturned)
+TEST(FizzBuzzTest, GivenFizzCustom4BuzzCustom6_WhenRunRange1To12_ThenCorrectStringReturned)
 {
     std::vector<std::string> expected = {"1", "2", "3", "Fizz", "5", "Buzz", "7", "Fizz", "9", "10", "11", "FizzBuzz"};
     FizzBuzz fizzBuzz;
-    fizzBuzz.SetFizzValue(4);
-    fizzBuzz.SetBuzzValue(6);
+    fizzBuzz.SetFizzMatcher(fizzOnMultipleOfFour);
+    fizzBuzz.SetBuzzMatcher(buzzOnMutlipleOfSix);
     std::vector<std::string> result = fizzBuzz.Run(1, 12);
+    EXPECT_THAT(result, Eq(expected));
+}
+
+TEST(FizzBuzzTest, GivenFizzCustomMatch4_WhenRunRange1To12_ThenCorrectStringReturned)
+{
+    std::vector<std::string> expected = {"1", "2", "3", "Fizz", "Buzz", "6", "7", "Fizz", "9", "Buzz", "11", "Fizz"};
+    FizzBuzz fizzBuzz;
+    fizzBuzz.SetFizzMatcher(fizzOnMultipleOfFour);
+    std::vector<std::string> result = fizzBuzz.Run(1, 12);
+    EXPECT_THAT(result, Eq(expected));
+}
+
+TEST(FizzBuzzTest, GivenBuzzCustomMatch6_WhenRunRange1To12_ThenCorrectStringReturned)
+{
+    std::vector<std::string> expected = {"1", "2", "Fizz", "4", "5", "FizzBuzz", "7", "8", "Fizz", "10", "11", "FizzBuzz"};
+    FizzBuzz fizzBuzz;
+    fizzBuzz.SetBuzzMatcher(buzzOnMutlipleOfSix);
+    std::vector<std::string> result = fizzBuzz.Run(1, 12);
+    EXPECT_THAT(result, Eq(expected));
+}
+
+TEST(FizzBuzzTest, GivenFizzBuzzMatchOnMultipleOrContainsDigit_WhenRunRange10To20_ThenCorrectStringReturned)
+{
+    std::vector<std::string> expected = {"Buzz", "11", "Fizz", "Fizz", "14", "FizzBuzz", "16", "17", "Fizz", "19", "Buzz"};
+    FizzBuzz fizzBuzz;
+    fizzBuzz.SetFizzMatcher(fizzOnMultipleOfOrContainsThree);
+    fizzBuzz.SetBuzzMatcher(buzzOnMutlipleOfOrContainsFive);
+    std::vector<std::string> result = fizzBuzz.Run(10, 20);
     EXPECT_THAT(result, Eq(expected));
 }
 
@@ -44,8 +104,6 @@ TEST(FizzBuzzTest,  WhenRunRangeLowerLimitLessThan0_ThenReturnsEmptyVector)
 {
     std::vector<std::string> expected = {};
     FizzBuzz fizzBuzz;
-    fizzBuzz.SetFizzValue();
-    fizzBuzz.SetBuzzValue();
     std::vector<std::string> result = fizzBuzz.Run(-1, 5);
     EXPECT_THAT(result, Eq(expected));
 }
@@ -54,8 +112,6 @@ TEST(FizzBuzzTest,  WhenRunRangeLowerLimit0_ThenReturnsEmptyVector)
 {
     std::vector<std::string> expected = {};
     FizzBuzz fizzBuzz;
-    fizzBuzz.SetFizzValue();
-    fizzBuzz.SetBuzzValue();
     std::vector<std::string> result = fizzBuzz.Run(0, 5);
     EXPECT_THAT(result, Eq(expected));
 }


### PR DESCRIPTION
Add a slightly incorrect interpretation of stage 2 of the FizzBuzz kata. A user can now provide a custom matcher function, allowing the ability to match to anything desired easily without editing the FizzBuzz class.